### PR TITLE
GKE sql proxy

### DIFF
--- a/datastores/as_kubernetes_pods/README.md
+++ b/datastores/as_kubernetes_pods/README.md
@@ -17,6 +17,18 @@ To create a MySQL deployment, the provided manifest under `manifests/mysql.yaml`
 ```
 kubectl create -f manifests/mysql.yaml --namespace sysdigcloud
 ```
+## Google Cloud SQL with CloudSQL proxy
+
+You'll need to create several Secret resources to allow the SQL proxy to connect with your SQL instance. First, you'll need to create a secret resource containing the Service Account credentials to allow the proxy to communicate with the Cloud SQL API.
+
+Run this command, making sure to replace <PATH_TO_CREDENTIAL_FILE> with the correct location of the JSON file of your service account:
+```
+kubectl create secret generic cloudsql-oauth-credentials --from-file=credentials.json=<PATH_TO_CREDENTIAL_FILE>
+```
+Then, run:
+
+kubectl create -f manifests/mysql-proxy.yaml 
+
 
 ## Redis
 

--- a/datastores/as_kubernetes_pods/manifests/mysql-proxy.yaml
+++ b/datastores/as_kubernetes_pods/manifests/mysql-proxy.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sysdigcloud-mysql
+  labels:
+    app: sysdigcloud
+    role: mysqlproxy
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: sysdigcloud
+    role: mysqlproxy
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: sysdigcloud-mysql
+spec:
+  template:
+    metadata:
+      labels:
+        app: sysdigcloud
+        role: mysqlproxy
+    spec:
+      containers:
+        # Change [INSTANCE_CONNECTION_NAME] here to include your GCP
+        # project, the region of your Cloud SQL instance and the name
+        # of your Cloud SQL instance. The format is
+        # -instances=$PROJECT:$REGION:INSTANCE=tcp:0.0.0.0:3306
+        # [START proxy_container]
+        - image: b.gcr.io/cloudsql-docker/gce-proxy:1.05
+          name: mysqlproxy
+          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+                    "-instances=INSTANCE_CONNECTION_NAME=tcp:0.0.0.0:3306",
+                    "-credential_file=/secrets/cloudsql/credentials.json"]
+          volumeMounts:
+            - name: cloudsql-oauth-credentials
+              mountPath: /secrets/cloudsql
+              readOnly: true
+            - name: ssl-certs
+              mountPath: /etc/ssl/certs
+            - name: cloudsql
+              mountPath: /cloudsql
+        # [END proxy_container]
+      # [START volumes]
+      volumes:
+        - name: cloudsql-oauth-credentials
+          secret:
+            secretName: cloudsql-oauth-credentials
+        - name: ssl-certs
+          hostPath:
+            path: /etc/ssl/certs
+      # [END volumes]
+

--- a/datastores/external_services/README.md
+++ b/datastores/external_services/README.md
@@ -10,3 +10,5 @@ redis.endpoint: <DNS/IP>
 
 #### MySQL notes:
 MySQL service requires a pre-existing schema named `draios` and character-set and collation configured to UTF-8
+`CREATE SCHEMA draios DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_unicode_ci;
+`


### PR DESCRIPTION
If customer want to use GKE CloudSQL v2.0 they will need to use CloudSQL proxy
instead of our MySQL pod.