### PR TITLE
Include mention of clock sync via NTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - Running Kubernetes cluster, Kubernetes version >= 1.3.X (this guide has been tested with Kubernetes 1.3.6)
 - Sysdig Cloud quay.io pull secret
 - Sysdig Cloud license
+- Host clocks should be kept synchronized via [NTP](http://www.ntp.org/)
 
 ### Infrastructure Overview
 


### PR DESCRIPTION
A recent issue with an on-prem install turned out to be due to clock skew between Collector/Worker hosts. We also know that Cassandra is dependent on synchronized clocks. Therefore, adding to the README a general recommendation of NTP clock sync for all hosts in general.

cc: @ltagliamonte 