### PR TITLE
Increase MySQL max_connections to 1024

### DIFF
--- a/datastores/as_kubernetes_pods/manifests/mysql.yaml
+++ b/datastores/as_kubernetes_pods/manifests/mysql.yaml
@@ -35,6 +35,7 @@ data:
     sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
     # Disabling symbolic-links is recommended to prevent assorted security risks
     symbolic-links=0
+    max_connections=1024
     !includedir /etc/mysql/conf.d/
 ---
 apiVersion: v1


### PR DESCRIPTION
See https://github.com/draios/infrastructure/pull/213 for detailed information on this change.

I tested it for K8S by bringing up a MySQL Pod using the `master` version of https://github.com/draios/sysdigcloud-kubernetes/blob/master/datastores/as_kubernetes_pods/manifests/mysql.yaml and then the same using the on in this branch:

Baseline from `master`:

```
mysql> show variables like 'max_connections';
+-----------------+-------+
| Variable_name   | Value |
+-----------------+-------+
| max_connections | 151   |
+-----------------+-------+
```

Verify with `mysql-increase-max-connections` branch:

```
mysql>  show variables like 'max_connections';
+-----------------+-------+
| Variable_name   | Value |
+-----------------+-------+
| max_connections | 1024  |
+-----------------+-------+
```