### PR TITLE
Document deprecated LDAP options in ConfigMap YAML

### DIFF
--- a/sysdigcloud/config.yaml
+++ b/sysdigcloud/config.yaml
@@ -96,6 +96,19 @@ data:
   sysdigcloud.google.oauth.client.secret: ""
   # Required: enable or disable Sysdig Cloud LDAP integration
   sysdigcloud.ldap.enabled: "false"
+  # ==== BEGIN DEPRECATED LDAP OPTIONS ====
+  # NOTE: The following series of optional LDAP settings are deprecated starting
+  # with version 890. If you have been using LDAP in a version older than 890,
+  # you should keep your settings intact until you successfully upgrade to 890
+  # or newer, at which time your settings from this ConfigMap will be migrated
+  # to a new API-based LDAP configuration. Once running version 890 or newer,
+  # you can remove these optional settings from this ConfigMap and only need to
+  # ensure the boolean setting for "sysdigcloud.ldap.enabled" above remains and
+  # is set to "true". See this support article for details on the API-based
+  # LDAP configuration:
+  #
+  #   https://sysdigdocs.atlassian.net/wiki/spaces/LDAP/pages/203620377/LDAP+Authentication+Configuration
+  #
   # Optional: LDAP server endpoint (eg: ldaps://1.2.3.4:636)
   sysdigcloud.ldap.endpoint: ""
   # Optional: LDAP DN manager (eg: cn=servicer_acccount,ou=Service accounts,dc=demo,dc=com)
@@ -124,4 +137,5 @@ data:
   sysdigcloud.ldap.group.membership.filter: ""
   # Optional: Store Sysdig captures using Cassandra instead of S3
   # NB. This affects cassandra storage
+  # ==== END DEPRECATED LDAP OPTIONS ====
   sysdigcloud.captures.cassandra.storage: "true"


### PR DESCRIPTION
Now that the new API-based LDAP support is GA, I'm concerned that users will see the "optional" LDAP settings in the ConfigMap and think that they are still the place to go to change their LDAP settings, but that will not be the case starting with release 890. I don't want to delete them altogether from the ConfigMap because legacy LDAP users need them to still be there for the first time they boot into 890+, at which time there will be a one-time auto-migration to the LDAP API-based config. But I wanted to mark them deprecated now as a first step, and point users to the new LDAP docs while I'm at it.

Some day many months from now if we believe all environments are running the new LDAP (and maybe when LDAP support is refactored so even the `sysdigcloud.ldap.enabled` becomes unnecessary), then we could remove them entirely from the ConfigMap.