### PR TITLE
Remove storageClassName from VolumeClaimTemplates

### DIFF
--- a/datastores/as_kubernetes_pods/manifests/cassandra/cassandra-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/cassandra/cassandra-statefulset.yaml
@@ -63,4 +63,3 @@ spec:
             resources:
               requests:
                 storage: 50Gi
-            storageClassName: standard

--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
@@ -48,4 +48,3 @@ spec:
                   resources:
                     requests:
                       storage: 50Gi
-                  storageClassName: standard


### PR DESCRIPTION
We don't know what storageClassName(s) will be available, so just go with the default.