### PR TITLE
More deprecated LDAP info in ConfigMap

### DIFF
--- a/sysdigcloud/config.yaml
+++ b/sysdigcloud/config.yaml
@@ -93,44 +93,42 @@ data:
   sysdigcloud.google.oauth.client.id: ""
   # Optional: Sysdig Cloud Google OAuth Client Secret
   sysdigcloud.google.oauth.client.secret: ""
-  # Required: enable or disable Sysdig Cloud LDAP integration
-  sysdigcloud.ldap.enabled: "false"
   # ======= BEGIN DEPRECATED LDAP OPTIONS =======
-  # NOTE: The following series of optional LDAP settings are deprecated starting
-  # with version 890. If you have been using LDAP in a version older than 890,
-  # you should keep your settings intact until you successfully upgrade to 890
+  # NOTE: The following series of LDAP settings are deprecated starting
+  # with version 963. If you have been using LDAP in a version older than 963,
+  # you should keep your settings intact until you successfully upgrade to 963
   # or newer, at which time your settings from this ConfigMap will be migrated
-  # to a new API-based LDAP configuration. Once running version 890 or newer,
-  # you can remove these optional settings from this ConfigMap and only need to
-  # ensure the boolean setting for "sysdigcloud.ldap.enabled" above remains and
-  # is set to "true". See this support article for details on the API-based
-  # LDAP configuration:
+  # to a new API-based LDAP configuration. Once running version 963 or newer,
+  # you can remove these LDAP settings from this ConfigMap and configure
+  # LDAP via the API as described in the following Support article:
   #
   #   https://sysdigdocs.atlassian.net/wiki/spaces/LDAP/pages/203620377/LDAP+Authentication+Configuration
   #
-  # Optional: LDAP server endpoint (eg: ldaps://1.2.3.4:636)
+  # (Deprecated - formerly Required): enable or disable Sysdig Cloud LDAP integration
+  sysdigcloud.ldap.enabled: "false"
+  # (Deprecated - formerly Optional): LDAP server endpoint (eg: ldaps://1.2.3.4:636)
   sysdigcloud.ldap.endpoint: ""
-  # Optional: LDAP DN manager (eg: cn=servicer_acccount,ou=Service accounts,dc=demo,dc=com)
+  # (Deprecated - formerly Optional): LDAP DN manager (eg: cn=servicer_acccount,ou=Service accounts,dc=demo,dc=com)
   sysdigcloud.ldap.manager.dn: ""
-  # Optional: LDAP Manager password
+  # (Deprecated - formerly Optional): LDAP Manager password
   sysdigcloud.ldap.manager.password: ""
-  # Optional: LDAP root DN
+  # (Deprecated - formerly Optional): LDAP root DN
   sysdigcloud.ldap.root.dn: ""
-  # Optional: LDAP user search base
+  # (Deprecated - formerly Optional): LDAP user search base
   # If you specify a relative DN (from the root DN), Sysdig Cloud will further narrow down searches to the sub-tree.
   sysdigcloud.ldap.user.search.base: ""
-  # Optional: LDAP user search filter (eg: (\&(objectClass=organizationalPerson)(sAMAccountName={0})).
+  # (Deprecated - formerly Optional): LDAP user search filter (eg: (\&(objectClass=organizationalPerson)(sAMAccountName={0})).
   # This field determines the query to be run to identify the user record. The query is almost always uid={0} as per defined in RFC 2798.
   # NB. Escape special characters like &
   sysdigcloud.ldap.user.search.filter: ""
-  # Optional: Group search base (eg: ou=Organization,ou=Users)
+  # (Deprecated - formerly Optional): Group search base (eg: ou=Organization,ou=Users)
   # This field determines the query to be run to identify the organizational unit that contains groups.
   sysdigcloud.ldap.group.search.base: ""
-  # Optional: Group search filter (eg: cn=sysdigcloud)
+  # (Deprecated - formerly Optional): Group search filter (eg: cn=sysdigcloud)
   # This field is used to determine if a named group exists. If you know your LDAP server only stores group information
   # in one specific object class, then you can improve group search performance by restricting the filter to just the required object class.
   sysdigcloud.ldap.group.search.filter: ""
-  # Optional: Group membership filter (eg: member={0})
+  # (Deprecated - formerly Optional): Group membership filter (eg: member={0})
   # The group membership filter field controls the search filter that is used to determine group membership.
   # You are normally safe leaving this field unchanged, the default value ( | (member={0}) (uniqueMember={0}) (memberUid={1})) will be used.
   sysdigcloud.ldap.group.membership.filter: ""


### PR DESCRIPTION
Back when we released 890, all LDAP settings other than base enable/disable had been moved to the API. As of 963, even base enable/disable is now in the API, so we can mark 100% of the LDAP settings as deprecated.