### PR TITLE
Add extra JVM GC parameters via configMap

### DIFF
--- a/sysdigcloud/config.yaml
+++ b/sysdigcloud/config.yaml
@@ -111,6 +111,8 @@ data:
   sysdigcloud.jvm.api.options: ""
   sysdigcloud.jvm.worker.options: ""
   sysdigcloud.jvm.collector.options: ""
+  # JVM GC options for the collectors
+  sysdigcloud.jvmgc.collector.options: "-XX:+PrintFlagsFinal -Xverify:none -XX:+UseG1GC -XX:MaxGCPauseMillis=300 -XX:+UseTLAB -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
   # Required: Sysdig Cloud license
   sysdigcloud.license: ""
   # Optional: OAuth allowed domains (comma separated list of domains)

--- a/sysdigcloud/sdc-collector.yaml
+++ b/sysdigcloud/sdc-collector.yaml
@@ -47,6 +47,11 @@ spec:
                 configMapKeyRef:
                   name: sysdigcloud-config
                   key: sysdigcloud.jvm.collector.options
+            - name: JAVA_GC_PARAMETERS
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-config
+                  key: sysdigcloud.jvmgc.collector.options
           # If you're running multiple replicas, it is advisable to configure the limits below. Limiting resources 
           # can help stabilize rolling updates later down the road.
           # resources:


### PR DESCRIPTION
- this adds an extra entry to the configMap so that one can pass specific JVM GC parameters to the collectors
- the values in the configMap are recommended following a deep investigation into the behaviour of the collectors JVMs
