### PR TITLE
Modify elasticsearch statefulset and service to improve clustering

### DIFF
--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-service.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-service.yaml
@@ -7,6 +7,7 @@ metadata:
     app: sysdigcloud
     role: elasticsearch
 spec:
+  publishNotReadyAddresses: true
   clusterIP: None
   ports:
     - port: 9200

--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-service.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: sysdigcloud-elasticsearch
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   labels:
     app: sysdigcloud
     role: elasticsearch

--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   serviceName: elasticsearch-data
   podManagementPolicy: "Parallel"
+  # The number of replicas needs to be passed to the pods by ensuring that the value of ELASTICSEARCH_GOSSIP_NODES_NUM
+  # matches the number set here.
   replicas: 3
   template:
     metadata:
@@ -45,6 +47,9 @@ spec:
         env:
         - name: ELASTICSEARCH_SERVICE
           value: sysdigcloud-elasticsearch
+          # This value needs to match the number of replicas specified for the statefulset. It will be used to calculate
+          # The value of the -Ediscovery.zen.minimum_master_nodes parameter. To override this calculation and set this
+          # parameter manually use the DISCOVERY_ZEN_MINIMUM_MASTER_NODES variable.
         - name: ELASTICSEARCH_GOSSIP_NODES_NUM
           value: "3"
         - name: ELASTICSEARCH_CLUSTER_NAME

--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
             #topologyKey: "kubernetes.io/hostname"
       containers:
       - name: elasticsearch
-        image: quay.io/sysdig/elasticsearch:5.6.13.3
+        image: quay.io/sysdig/elasticsearch:5.6.13.4
         securityContext:
           privileged: true
         resources:

--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
@@ -9,6 +9,7 @@ metadata:
     role: elasticsearch
 spec:
   serviceName: elasticsearch-data
+  podManagementPolicy: "Parallel"
   replicas: 3
   template:
     metadata:
@@ -33,7 +34,7 @@ spec:
             #topologyKey: "kubernetes.io/hostname"
       containers:
       - name: elasticsearch
-        image: quay.io/sysdig/elasticsearch:5.6.13.2
+        image: quay.io/sysdig/elasticsearch:5.6.13.3
         securityContext:
           privileged: true
         resources:
@@ -45,7 +46,7 @@ spec:
         - name: ELASTICSEARCH_SERVICE
           value: sysdigcloud-elasticsearch
         - name: ELASTICSEARCH_GOSSIP_NODES_NUM
-          value: "2"
+          value: "3"
         - name: ELASTICSEARCH_CLUSTER_NAME
           value: sysdigcloud
         - name: ES_JAVA_OPTS

--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
@@ -36,7 +36,7 @@ spec:
             #topologyKey: "kubernetes.io/hostname"
       containers:
       - name: elasticsearch
-        image: quay.io/sysdig/elasticsearch:5.6.13.4
+        image: quay.io/sysdig/elasticsearch:5.6.13.5
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
This change coincides with proposed changes to the elasticsearch container for sysdigcloud. 

It would allow elasticsearch pods to use the headless service with the `publishNotReadyAddresses` feature enabled to detect the other nodes during startup in order to initiate clustering properly. 

This requires a change to the statefulset to enable the Parallel pod management policy so that the elasticsearch pods start simultaneously and can detect each other right away in order to negotiate clustering effectively.