### PR TITLE
Update storage tag in mysql deployment to use same as other yamls

### DIFF
--- a/datastores/as_kubernetes_pods/manifests/mysql/mysql-deployment.yaml
+++ b/datastores/as_kubernetes_pods/manifests/mysql/mysql-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  storageClassName: <INSERT YOUR STORAGE CLASS HERE>
+  storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
   resources:
     requests:
       storage: 15Gi


### PR DESCRIPTION
So in the QA scripts we can use the same sed to replace all the values and the tag it's the same that the one referenced in the README