### PR TITLE
specifying "None" for the cluster IP (.spec.clusterIP).

### DIFF
--- a/sysdigcloud/api-clusterip-service.yaml
+++ b/sysdigcloud/api-clusterip-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: sysdigcloud
     role: api
 spec:
-  type: ClusterIP
+  clusterIP: None
   ports:
     - port: 8080
       name: internal-api


### PR DESCRIPTION
This option allows the ability to reduce coupling to the Kubernetes system by allowing freedom to do discovery their own way. Applications can still use a self-registration pattern and adapters for other discovery systems could easily be built upon this API.
For headless services that define selectors, the endpoints controller creates Endpoints records in the API, and modifies the DNS configuration to return A records (addresses) that point directly to the Pods backing the Service