### PR TITLE
comment out references to scanning database

### DIFF
--- a/datastores/as_kubernetes_pods/manifests/mysql/mysql-cluster-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/mysql/mysql-cluster-statefulset.yaml
@@ -104,21 +104,23 @@ spec:
                 configMapKeyRef:
                   key: mysql.password
                   name: sysdigcloud-config
-            - name: MYSQL_EXTRADB_SCANNING_DBNAME
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-config
-                  key: scanning.mysql.dbname
-            - name: MYSQL_EXTRADB_SCANNING_USER
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-config
-                  key: scanning.mysql.user
-            - name: MYSQL_EXTRADB_SCANNING_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: sysdigcloud-scanning
-                  key: scanning.mysql.password
+            # These MYSQL_EXTRADB_* enviroment variables will trigger the
+            # creation of the scanning database when mysql starts.
+            # - name: MYSQL_EXTRADB_SCANNING_DBNAME
+            #   valueFrom:
+            #     configMapKeyRef:
+            #       name: sysdigcloud-config
+            #       key: scanning.mysql.dbname
+            # - name: MYSQL_EXTRADB_SCANNING_USER
+            #   valueFrom:
+            #     configMapKeyRef:
+            #       name: sysdigcloud-config
+            #       key: scanning.mysql.user
+            # - name: MYSQL_EXTRADB_SCANNING_PASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: sysdigcloud-scanning
+            #       key: scanning.mysql.password
             - name: MYSQL_ROOT_HOST
               value: '%'
             - name: MYSQL_LOG_CONSOLE

--- a/datastores/as_kubernetes_pods/manifests/mysql/mysql-deployment.yaml
+++ b/datastores/as_kubernetes_pods/manifests/mysql/mysql-deployment.yaml
@@ -105,21 +105,23 @@ spec:
                   key: mysql.password
             - name: MYSQL_DATABASE
               value: draios
-            - name: MYSQL_EXTRADB_SCANNING_DBNAME
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-config
-                  key: scanning.mysql.dbname
-            - name: MYSQL_EXTRADB_SCANNING_USER
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-config
-                  key: scanning.mysql.user
-            - name: MYSQL_EXTRADB_SCANNING_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: sysdigcloud-scanning
-                  key: scanning.mysql.password
+            # These MYSQL_EXTRADB_* enviroment variables will trigger the
+            # creation of the scanning database when mysql starts.
+            # - name: MYSQL_EXTRADB_SCANNING_DBNAME
+            #   valueFrom:
+            #     configMapKeyRef:
+            #       name: sysdigcloud-config
+            #       key: scanning.mysql.dbname
+            # - name: MYSQL_EXTRADB_SCANNING_USER
+            #   valueFrom:
+            #     configMapKeyRef:
+            #       name: sysdigcloud-config
+            #       key: scanning.mysql.user
+            # - name: MYSQL_EXTRADB_SCANNING_PASSWORD
+            #   valueFrom:
+            #     secretKeyRef:
+            #       name: sysdigcloud-scanning
+            #       key: scanning.mysql.password
           volumeMounts:
             - name: mysql-config
               mountPath: /etc/mysql/my.cnf


### PR DESCRIPTION
This allows us to keep the existing k8s install instructions intact.