### PR TITLE
Fix statefulset service naming

### DIFF
--- a/datastores/as_kubernetes_pods/manifests/cassandra/cassandra-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/cassandra/cassandra-statefulset.yaml
@@ -4,7 +4,7 @@ kind: StatefulSet
 metadata:
   name: sysdigcloud-cassandra
 spec:
-  serviceName: cassandra-service
+  serviceName: sysdigcloud-cassandra
   replicas: 3
   selector:
     matchLabels:

--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     component: elasticsearch
     role: elasticsearch
 spec:
-  serviceName: elasticsearch-data
+  serviceName: sysdigcloud-elasticsearch
   podManagementPolicy: "Parallel"
   # The number of replicas needs to be passed to the pods by ensuring that the value of ELASTICSEARCH_GOSSIP_NODES_NUM
   # matches the number set here.


### PR DESCRIPTION
In order for DNS resolution to work inside the pods for the FQDN of each statefulset member the statefulset's `{spec: { serviceName: }}` value needs to match the name of the associated kubernetes service.