### PR TITLE
Image Scanning Feed service for Air-gapped deployment (kubernetes)

### DIFF
--- a/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-config.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-config.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sysdigcloud-anchore-feeds
+  labels:
+    app: sysdigcloud
+    role: anchore-feeds
+data:
+  anchore.admin.user: admin
+  anchore.db.endpoint: sysdigcloud-anchore-feeds-db-ext
+  anchore.db.dbname: anchore
+  anchore.db.user: postgres
+  config.yaml: |
+    service_dir: /anchore_service_config
+    tmp_dir: "/tmp"
+    log_level: INFO
+    cleanup_images: true
+
+    allow_awsecr_iam_auto: false
+    host_id: "${ANCHORE_POD_NAME}"
+    internal_ssl_verify: false
+    auto_restart_services: false
+    license_file: "/license/license.yaml"
+
+    metrics:
+      enabled: false
+
+    credentials:
+      database:
+        db_connect: "postgresql+pg8000://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_ENDPOINT}/${ANCHORE_DB}"
+        db_connect_args:
+          timeout: 120
+          ssl: false
+        db_pool_size: 30
+        db_pool_max_overflow: 30
+
+    services:
+      feeds:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: sysdigcloud-anchore-feeds
+        listen: '0.0.0.0'
+        port: 8448
+        # Time delay in seconds between consecutive driver runs for processing data
+        cycle_timers:
+          driver_sync: 7200
+        # Staging space for holding normalized output from drivers.
+        local_workspace: /tmp
+        # Drivers process data from external sources and store normalized data in local_workspace. Processing large data sets
+        # is a time consuming process for some drivers. To speed it up the container is shipped with pre-loaded data which is used
+        # by default if local_workspace is empty.
+        workspace_preload:
+          # Do not use pre-loaded data if local_workspace is empty. Drivers will generate normalized data from scratch
+          disabled: true
+          # To load the workspace from a different location, uncomment and configure workspace_preload_file property to point to the tar.gz file
+          workspace_preload_file: "/workspace_preload/data.tar.gz"
+        # If api_only is set to true, the service will not update feed data in the system.
+        # API end points will be functional and serve feed data if any is available.
+        api_only: true
+        drivers:
+          # Configuration section for drivers collecting and processing feed data.
+          # All drivers are enabled by default unless explicitly disabled. npm and gem drivers are explicitly disabled out of the box
+          npm:
+            enabled: true
+          gem:
+            # rubygem data comes packaged as a PostgreSQL dump file. gem driver loads the pg dump and normalizes the data.
+            # To enable gem driver comment the enabled property and uncomment the db_connect property.
+            enabled: false
+            db_connect: "postgresql+pg8000://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_ENDPOINT}/${ANCHORE_DB}/gems"
+          centos:
+            enabled: true
+          debian:
+            enabled: true
+          ubuntu:
+            enabled: true
+          ol:
+            enabled: true
+          alpine:
+            enabled: true
+          snyk:
+            enabled: true
+        certDir: ""
+        ssl_cert: ""
+        ssl_key: ""
+        ssl_enable: false
+        ssl_verify: false

--- a/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-db-service.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-db-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sysdigcloud-anchore-feeds-db-ext
+  labels:
+    app: sysdigcloud
+    role: anchore-feeds-db
+spec:
+  type: ClusterIP
+  ports:
+  - name: anchore-feeds-db
+    port: 5432
+    protocol: TCP
+    targetPort: feeds-db
+  selector:
+    app: sysdigcloud
+    role: anchore-feeds-db

--- a/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-db-statefulset.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-db-statefulset.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sysdigcloud-anchore-feeds-db-ext
+  labels:
+    app: sysdigcloud
+    role: anchore-feeds-db
+spec:
+  # Stateful service, replica should never be greater than 1
+  replicas: 1
+  serviceName: "sysdigcloud-anchore-feeds-db-ext"
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: sysdigcloud
+      role: anchore-feeds-db
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+       - ReadWriteOnce
+      storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
+      resources:
+        requests:
+          storage: 8Gi
+  template:
+    metadata:
+      labels:
+        app: sysdigcloud
+        role: anchore-feeds-db
+    spec:
+      imagePullSecrets:
+        - name: sysdigcloud-pull-secret
+      volumes:
+        - name: config-volume
+          configMap:
+            name: sysdigcloud-anchore-feeds
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: role
+                  operator: In
+                  values:
+                  - anchore-feeds
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: postgresql
+        image: quay.io/sysdig/postgres:10.6
+        resources: {}
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data/pgdata
+          subPath: "postgresql-db"
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.user
+          # Required for pg_isready in the health probes.
+        - name: PGUSER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.user
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.dbname
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.password
+        - name: POD_IP
+          valueFrom: { fieldRef: { fieldPath: status.podIP } }
+        ports:
+        - name: feeds-db
+          containerPort: 5432
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          periodSeconds: 5

--- a/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-deployment.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-deployment.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sysdigcloud-anchore-feeds
+  labels:
+    app: sysdigcloud
+    role: anchore-feeds
+spec:
+  selector:
+    matchLabels:
+      app: sysdigcloud
+      role: anchore-feeds
+  replicas: 1
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        app: sysdigcloud
+        role: anchore-feeds
+    spec:
+      imagePullSecrets:
+        - name: sysdigcloud-pull-secret
+      volumes:
+        - name: config-volume
+          configMap:
+            name: sysdigcloud-anchore-feeds
+        - name: anchore-license
+          secret:
+            secretName: anchore-enterprise-license
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: role
+                  operator: In
+                  values:
+                  - anchore-feeds-db
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: anchore-feeds
+        image: quay.io/sysdig/anchore-feed:v0.3.2
+        imagePullPolicy: Always
+        command: ["/usr/local/bin/anchore-enterprise-manager"]
+        args: ["service", "start", "feeds"]
+        ports:
+        - containerPort: 8448
+          name: feeds-api
+        env:
+        - name: ANCHORE_DB
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.dbname
+        - name: ANCHORE_DB_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.endpoint
+        - name: ANCHORE_DB_USER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.user
+        - name: ANCHORE_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.password
+        - name: ANCHORE_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.admin.password
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ANCHORE_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ANCHORE_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        # See comments in sysdigcloud/config.yaml on how to specify anchore.https.proxy:
+        # https://github.com/draios/sysdigcloud-kubernetes/blob/master/sysdigcloud/config.yaml
+        # - name: https_proxy
+        #   valueFrom:
+        #     configMapKeyRef:
+        #       name: sysdigcloud-config
+        #       key: anchore.https.proxy
+        volumeMounts:
+        - name: config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        - name: anchore-license
+          mountPath: /license/
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: feeds-api
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: feeds-api
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          limits:
+            cpu: 300m
+            memory: 8Gi
+          requests:
+            cpu: 100m
+            memory: 3Gi

--- a/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-secret.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sysdigcloud-anchore-feeds
+  labels:
+    app: sysdigcloud
+type: Opaque
+stringData:
+  anchore.admin.password: change_me_this_is_clearly_not_a_good_password
+  anchore.db.password: change_me_this_is_clearly_not_a_good_password

--- a/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-service.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sysdigcloud-anchore-feeds
+  labels:
+    app: sysdigcloud
+    role: anchore-feeds
+spec:
+  type: ClusterIP
+  ports:
+  - name: feeds-api
+    port: 8448
+    protocol: TCP
+    targetPort: 8448
+  selector:
+    app: sysdigcloud
+    role: anchore-feeds

--- a/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-config.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-config.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sysdigcloud-anchore-feeds
+  labels:
+    app: sysdigcloud
+    role: anchore-feeds
+data:
+  anchore.admin.user: admin
+  anchore.db.endpoint: sysdigcloud-anchore-feeds-db
+  anchore.db.dbname: anchore
+  anchore.db.user: postgres
+  config.yaml: |
+    service_dir: /anchore_service_config
+    tmp_dir: "/tmp"
+    log_level: INFO
+    cleanup_images: true
+
+    allow_awsecr_iam_auto: false
+    host_id: "${ANCHORE_POD_NAME}"
+    internal_ssl_verify: false
+    auto_restart_services: false
+    license_file: "/license/license.yaml"
+
+    metrics:
+      enabled: false
+
+    credentials:
+      database:
+        db_connect: "postgresql+pg8000://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_ENDPOINT}/${ANCHORE_DB}"
+        db_connect_args:
+          timeout: 120
+          ssl: false
+        db_pool_size: 30
+        db_pool_max_overflow: 30
+
+    services:
+      feeds:
+        enabled: true
+        require_auth: true
+        endpoint_hostname: sysdigcloud-anchore-feeds
+        listen: '0.0.0.0'
+        port: 8448
+        # Time delay in seconds between consecutive driver runs for processing data
+        cycle_timers:
+          driver_sync: 7200
+        # Staging space for holding normalized output from drivers.
+        local_workspace: /tmp
+        # Drivers process data from external sources and store normalized data in local_workspace. Processing large data sets
+        # is a time consuming process for some drivers. To speed it up the container is shipped with pre-loaded data which is used
+        # by default if local_workspace is empty.
+        workspace_preload:
+          # Do not use pre-loaded data if local_workspace is empty. Drivers will generate normalized data from scratch
+          disabled: true
+          # To load the workspace from a different location, uncomment and configure workspace_preload_file property to point to the tar.gz file
+          workspace_preload_file: "/workspace_preload/data.tar.gz"
+        # If api_only is set to true, the service will not update feed data in the system.
+        # API end points will be functional and serve feed data if any is available.
+        api_only: true
+        drivers:
+          # Configuration section for drivers collecting and processing feed data.
+          # All drivers are enabled by default unless explicitly disabled. npm and gem drivers are explicitly disabled out of the box
+          npm:
+            enabled: true
+          gem:
+            # rubygem data comes packaged as a PostgreSQL dump file. gem driver loads the pg dump and normalizes the data.
+            # To enable gem driver comment the enabled property and uncomment the db_connect property.
+            enabled: true
+            db_connect: "postgresql+pg8000://${ANCHORE_DB_USER}:${ANCHORE_DB_PASSWORD}@${ANCHORE_DB_ENDPOINT}/${ANCHORE_DB}/gems"
+          centos:
+            enabled: true
+          debian:
+            enabled: true
+          ubuntu:
+            enabled: true
+          ol:
+            enabled: true
+          alpine:
+            enabled: true
+          snyk:
+            enabled: true
+        certDir: ""
+        ssl_cert: ""
+        ssl_key: ""
+        ssl_enable: false
+        ssl_verify: false

--- a/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-db-service.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-db-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sysdigcloud-anchore-feeds-db
+  labels:
+    app: sysdigcloud
+    role: anchore-feeds-db
+spec:
+  type: ClusterIP
+  ports:
+  - name: anchore-feeds-db
+    port: 5432
+    protocol: TCP
+    targetPort: feeds-db
+  selector:
+    app: sysdigcloud
+    role: anchore-feeds-db

--- a/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-db-statefulset.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-db-statefulset.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sysdigcloud-anchore-feeds-db
+  labels:
+    app: sysdigcloud
+    role: anchore-feeds-db
+spec:
+  # Stateful service, replica should never be greater than 1
+  replicas: 1
+  serviceName: "sysdigcloud-anchore-feeds"
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: sysdigcloud
+      role: anchore-feeds-db
+  volumeClaimTemplates:
+  - metadata:
+      name: anchore-feeds-data
+    spec:
+      accessModes:
+       - ReadWriteOnce
+      storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
+      resources:
+        requests:
+          storage: 5Gi
+  template:
+    metadata:
+      labels:
+        app: sysdigcloud
+        role: anchore-feeds-db
+    spec:
+      imagePullSecrets:
+        - name: sysdigcloud-pull-secret
+      volumes:
+        - name: config-volume
+          configMap:
+            name: sysdigcloud-anchore-feeds
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: role
+                  operator: In
+                  values:
+                  - anchore-feeds
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: postgresql
+        image: quay.io/sysdig/postgres:10.6
+        resources: {}
+        volumeMounts:
+        - name: anchore-feeds-data
+          mountPath: /var/lib/postgresql/data/pgdata
+          subPath: "postgresql-db"
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.user
+          # Required for pg_isready in the health probes.
+        - name: PGUSER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.user
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.dbname
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.password
+        - name: POD_IP
+          valueFrom: { fieldRef: { fieldPath: status.podIP } }
+        ports:
+        - name: feeds-db
+          containerPort: 5432
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          periodSeconds: 5

--- a/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-deployment.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-deployment.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sysdigcloud-anchore-feeds
+  labels:
+    app: sysdigcloud
+    role: anchore-feeds
+spec:
+  selector:
+    matchLabels:
+      app: sysdigcloud
+      role: anchore-feeds
+  replicas: 1
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        app: sysdigcloud
+        role: anchore-feeds
+    spec:
+      imagePullSecrets:
+        - name: sysdigcloud-pull-secret
+      volumes:
+        - name: config-volume
+          configMap:
+            name: sysdigcloud-anchore-feeds
+        - name: anchore-license
+          secret:
+            secretName: anchore-enterprise-license
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: role
+                  operator: In
+                  values:
+                  - anchore-feeds-db
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+      - name: anchore-feeds
+        image: quay.io/sysdig/anchore-feed:v0.3.2
+        imagePullPolicy: Always
+        command: ["/usr/local/bin/anchore-enterprise-manager"]
+        args: ["service", "start", "feeds"]
+        ports:
+        - containerPort: 8448
+          name: feeds-api
+        env:
+        - name: ANCHORE_DB
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.dbname
+        - name: ANCHORE_DB_ENDPOINT
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.endpoint
+        - name: ANCHORE_DB_USER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.user
+        - name: ANCHORE_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.password
+        - name: ANCHORE_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.admin.password
+        - name: ANCHORE_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: ANCHORE_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ANCHORE_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        # See comments in sysdigcloud/config.yaml on how to specify anchore.https.proxy:
+        # https://github.com/draios/sysdigcloud-kubernetes/blob/master/sysdigcloud/config.yaml
+        # - name: https_proxy
+        #   valueFrom:
+        #     configMapKeyRef:
+        #       name: sysdigcloud-config
+        #       key: anchore.https.proxy
+        volumeMounts:
+        - name: config-volume
+          mountPath: /config/config.yaml
+          subPath: config.yaml
+        - name: anchore-license
+          mountPath: /license/
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: feeds-api
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: feeds-api
+          timeoutSeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+          successThreshold: 1
+        resources:
+          limits:
+            cpu: 300m
+            memory: 8Gi
+          requests:
+            cpu: 100m
+            memory: 3Gi

--- a/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-secret.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-secret.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sysdigcloud-anchore-feeds
+  labels:
+    app: sysdigcloud
+type: Opaque
+stringData:
+  anchore.admin.password: change_me_this_is_clearly_not_a_good_password
+  anchore.db.password: change_me_this_is_clearly_not_a_good_password

--- a/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-service.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sysdigcloud-anchore-feeds
+  labels:
+    app: sysdigcloud
+    role: anchore-feeds
+spec:
+  type: ClusterIP
+  ports:
+  - name: feeds-api
+    port: 8448
+    protocol: TCP
+    targetPort: 8448
+  selector:
+    app: sysdigcloud
+    role: anchore-feeds


### PR DESCRIPTION
This change introduces the required yaml files for the kubernetes
installation of the Feed service required for image scanning in
air-gapped envs.

Refer to the following docs:
https://docs.google.com/document/d/1GPYqNqVua7TERdUpftCAPsdmb3UHLS_cnNsvMaTEosc
https://docs.google.com/document/d/1qAx1RFu2A6vfjNCg3BTVdq4GKTwEgEYLq_Ls8mPcyPU