### PR TITLE
Enable Stats Port

### DIFF
--- a/sysdigcloud/ingress_controller/ingress-daemonset.yaml
+++ b/sysdigcloud/ingress_controller/ingress-daemonset.yaml
@@ -41,6 +41,10 @@ spec:
               hostPort: 443
               name: https
               protocol: TCP
+            - containerPort: 1936
+              hostPort: 1936
+              name: stats
+              protocol: TCP
           readinessProbe:
               failureThreshold: 3
               httpGet:


### PR DESCRIPTION
We have a default app check for haproxy that doesn't work since we don't open up the port.  As a result there is a red X that customers ask about out of the box.  This 4 line fix will allow people to look at the haproxy stats.