### PR TITLE
Install binaries into well defined PATHS.

### DIFF
--- a/configurator/Dockerfile
+++ b/configurator/Dockerfile
@@ -1,14 +1,21 @@
 FROM alpine:3.9.4
 
-RUN apk add python py-pip jq openssl
-RUN pip install yq
-
-RUN mkdir -p helm kubernetes/kubernetes-cli openshift
-RUN wget https://storage.googleapis.com/kubernetes-helm/helm-v2.14.0-linux-386.tar.gz && tar xvf helm-v2.14.0-linux-386.tar.gz -C helm/ && rm helm-v2.14.0-linux-386.tar.gz
-RUN wget https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -O kubernetes/kustomize
-RUN wget https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl -O kubernetes/kubernetes-cli/kubectl
-RUN chmod u+x kubernetes/kustomize kubernetes/kubernetes-cli/kubectl*
-RUN export PATH=$PATH:/helm/linux-386/:/kubernetes:/kubernetes/kubernetes-cli
-RUN wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz && tar xvf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -C openshift && rm openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz
+RUN apk add python py-pip jq openssl \
+      && pip install yq \
+      && wget https://storage.googleapis.com/kubernetes-helm/helm-v2.14.0-linux-386.tar.gz \
+      && tar xvf helm-v2.14.0-linux-386.tar.gz -C /tmp \
+      && cp /tmp/linux-386/helm /usr/bin/ \
+      && rm helm-v2.14.0-linux-386.tar.gz \
+      && wget https://github.com/kubernetes-sigs/kustomize/releases/download/v2.0.3/kustomize_2.0.3_linux_amd64 -O /usr/bin/kustomize \
+      && wget https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl -O /usr/bin/kubectl \
+      && chmod u+x /usr/bin/kustomize /usr/bin/kubectl* \
+      && wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz \
+      && tar xvf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -C /tmp \
+      && echo -e "#!/bin/sh\n/lib/ld-musl-x86_64.so.1 --library-path /lib /usr/bin/oc-bin \$@" > /usr/bin/oc \
+      && echo -e "#!/bin/sh\n/lib/ld-musl-x86_64.so.1 --library-path /lib /usr/bin/oc-kubectl-bin \$@" > /usr/bin/oc-kubectl \
+      && chmod +x /usr/bin/oc /usr/bin/oc-kubectl \
+      && cp /tmp/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/kubectl /usr/bin/oc-kubectl-bin \
+      && cp /tmp/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc /usr/bin/oc-bin \
+      && rm -rf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz /tmp/openshift* linux-386 \
 
 ENTRYPOINT /sysdig-chart/install.sh

--- a/configurator/sysdig-chart/framework.sh
+++ b/configurator/sysdig-chart/framework.sh
@@ -1,6 +1,5 @@
 #!/bin/ash
 
-export PATH=$PATH:/helm/linux-386/:/kubernetes:/kubernetes/kubernetes-cli
 NAMESPACE=$(cat /sysdig-chart/values.yaml | yq .namespace | tr -d '"')
 
 #Echo function

--- a/configurator/sysdig-chart/generate_templates.sh
+++ b/configurator/sysdig-chart/generate_templates.sh
@@ -1,6 +1,5 @@
 #!/bin/ash
 set -euo pipefail
-export PATH=$PATH:/helm/linux-386/:/kubernetes:/kubernetes/kubernetes-cli
 
 TEMPLATE_DIR=/sysdig-chart
 #apps selection


### PR DESCRIPTION
This cleans up the dockerfile into a single RUN so we have one layer
instead N of them, also installs the binaries into `/usr/bin` which
prevents the need to modify PATH. Openshift specific kubectl is
prepended with `oc` e.g `oc-kubectl`.