### PR TITLE
DEVOPS-1805: Build configurator images from Jenkins.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,38 @@
+pipeline {
+  agent {
+    node { label "${WORKER}" }
+  }
+  environment {
+    registryCredential = 'jenkins-artifactory'
+    dockerImage = ''
+  }
+  stages {
+    stage('Build image') {
+      steps{
+        withCredentials([string(credentialsId: 'ARTIFACTORY_URL', variable: 'ARTIFACTORY_URL')]) {
+          script {
+            dockerImage = docker.build("${ARTIFACTORY_URL}/configurator:${env.BUILD_NUMBER}", './configurator/')
+          }
+        }
+      }
+    }
+    stage('Push image') {
+      steps {
+        withCredentials([string(credentialsId: 'ARTIFACTORY_URL', variable: 'ARTIFACTORY_URL')]) {
+          script {
+            docker.withRegistry("https://${ARTIFACTORY_URL}", registryCredential) {
+              dockerImage.push()
+            }
+          }
+        }
+      }
+    }
+    stage('Cleanup') {
+      steps {
+        withCredentials([string(credentialsId: 'ARTIFACTORY_URL', variable: 'ARTIFACTORY_URL')]) {
+          sh "docker rmi ${ARTIFACTORY_URL}/configurator:${env.BUILD_NUMBER}"
+        }
+      }
+    }
+  }
+}

--- a/configurator/Dockerfile
+++ b/configurator/Dockerfile
@@ -18,4 +18,6 @@ RUN apk add python py-pip jq openssl ca-certificates \
       && cp /tmp/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc /usr/bin/oc-bin \
       && rm -rf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz /tmp/openshift* linux-386
 
+COPY sysdig-chart /sysdig-chart
+
 ENTRYPOINT /sysdig-chart/install.sh


### PR DESCRIPTION
This will build configurator images from Jenkins that includes all of
our configuration, which will eliminate the need for the user to clone
and build the images themselves.

Currently I plan to make this a single branch Jenkins pipeline and build
only images from a "blessed" branch, if we find need for building all
branches we can revisit this decision.