### PR TITLE
Fix helm templates and values.yaml.

### DIFF
--- a/configurator/sysdig-chart/templates/common-config/config.yaml
+++ b/configurator/sysdig-chart/templates/common-config/config.yaml
@@ -80,11 +80,11 @@ data:
   # This conditional has to be kept here because golang templates do not
   # support nesting if conditionals, it expects an if conditional to close at an
   # end statement.
-  {{ if (and (eq (.Values.cloudProvider.name | default "") "aws") (hasSuffix "1" .Values.cloudProvider.region)) }}
-  {{ $ec2Region := (substr 0 (int (sub (len .Values.cloudProvider.region) 2)) .Values.cloudProvider.region) }}
+  {{ if (and (eq (.Values.cloudProvider.name | default "") "aws") (hasSuffix "1" (.Values.cloudProvider.region | default ""))) }}
+  {{ $ec2Region := (substr 0 (int (sub (len (.Values.cloudProvider.region | default "")) 2)) (.Values.cloudProvider.region | default "")) }}
   cassandra.datacenter.name: {{ $ec2Region }}
   {{ else if (eq (.Values.cloudProvider.name | default "") "aws") }}
-  cassandra.datacenter.name: {{ .Values.cloudProvider.region }}
+  cassandra.datacenter.name: {{ (.Values.cloudProvider.region | default "") }}
   {{ end }}
 
   {{ if (and (eq (.Values.cloudProvider.name | default "") "aws") (.Values.cloudProvider.isMultiAZ | default false)) }}

--- a/configurator/sysdig-chart/values.yaml
+++ b/configurator/sysdig-chart/values.yaml
@@ -17,12 +17,13 @@ quaypullsecret: <Insert QuaySecret>
 storageClassName: <Insert StorageClassName>
 #This drives multi-az awareness, if sysdigcloud is deployed to a multi-az setup
 #this should be updated as adequate
-# cloudProvider:
-#   defaults to an empty string
-#   name: aws
-#   defaults to false
-#   isMultiAZ: true
-#   region: us-east-1
+cloudProvider:
+  # example aws
+  name:
+  # boolean true|false
+  isMultiAZ: false
+  # example us-east-1
+  region: ""
 #supports aws | gke
 storageClassProvisioner: aws
 #supports openshift | kubernetes defaults to kubernetes install


### PR DESCRIPTION
`default` function in helm only works when the top level key is absent,
for hierarchical data, the hierarchy must be present and `default` will
fill in if the value is absent.

This also addressed lookups that had missing defaults.

This was an oversight I did not test after commenting out the fields, as
it currently is the fields cannot be commented out otherwise things will
break.