### PR TITLE
DEVOPS-1894-Increase-memory-limits-redis-sentinel

### DIFF
--- a/datastores/as_kubernetes_pods/manifests/redis/redis-sentinel-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-sentinel-statefulset.yaml
@@ -37,10 +37,10 @@ spec:
         resources:
           limits:
             cpu: 300m
-            memory: 10Mi
+            memory: 20Mi
           requests:
             cpu: 50m
-            memory: 2Mi
+            memory: 5Mi
         ports:
         - containerPort: 26379
           name: redis-sentinel


### PR DESCRIPTION
with 10Mi limits the pod doesnt start. Hence increasing. 