### PR TITLE
Remove reload-strategy configured for HAProxy ingress controller.

### DIFF
--- a/sysdigcloud/ingress_controller/ingress-daemonset.yaml
+++ b/sysdigcloud/ingress_controller/ingress-daemonset.yaml
@@ -34,7 +34,6 @@ spec:
         - name: haproxy-ingress
           image: quay.io/sysdig/haproxy-ingress:v0.7-beta.7
           args:
-              - --reload-strategy=multibinder
               - --default-backend-service=$(POD_NAMESPACE)/ingress-default-backend
               - --allow-cross-namespace
               - --configmap=$(POD_NAMESPACE)/haproxy-ingress


### PR DESCRIPTION
The strategy has been deprecated:

https://github.com/jcmoraisjr/haproxy-ingress/tree/v0.7-beta.7#reload-strategy

also the HAProxy version we run:

```
haproxy -v
HA-Proxy version 1.8.17 2019/01/08
Copyright 2000-2019 Willy Tarreau <willy@haproxy.org>
```

supports safe reload out of the box:

https://www.haproxy.com/blog/truly-seamless-reloads-with-haproxy-no-more-hacks/

so we should not have to configure anything to get the safe reload
behavior.