### PR TITLE
SSPROD-1566 : Increasing default audit events in onprem t0 100k

### DIFF
--- a/sysdigcloud/config.yaml
+++ b/sysdigcloud/config.yaml
@@ -210,7 +210,7 @@ data:
   # The following settings are needed for configuring AUDIT EVENTS LOGGING
   audit.events.storage.type: "MYSQL"
   audit.events.retention.days: "14"
-  audit.events.max.events.per.day: "1000"
+  audit.events.max.events.per.day: "100000"
 
   ####################################
   # ======= BEGIN DEPRECATED LDAP OPTIONS =======


### PR DESCRIPTION
SSPROD-1566 : Increasing default audit events in onprem to 100k.
This is based on the PR I gave to dev branch for the same : https://github.com/draios/sysdigcloud-kubernetes/pull/324/files.