### PR TITLE
DEVOPS-2372 - bump docker image cve version tags

### DIFF
--- a/datastores/as_kubernetes_pods/manifests/cassandra/cassandra-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/cassandra/cassandra-statefulset.yaml
@@ -31,13 +31,13 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: affinity
-                    operator: In
-                    values:
-                      - cassandra
-              topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: affinity
+                operator: In
+                values:
+                - cassandra
+            topologyKey: kubernetes.io/hostname
       containers:
         - image: quay.io/sysdig/cassandra:2.1.21.15
           name: cassandra

--- a/datastores/as_kubernetes_pods/manifests/cassandra/cassandra-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/cassandra/cassandra-statefulset.yaml
@@ -31,15 +31,15 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: affinity
-                operator: In
-                values:
-                - cassandra
-            topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: affinity
+                    operator: In
+                    values:
+                      - cassandra
+              topologyKey: kubernetes.io/hostname
       containers:
-        - image: quay.io/sysdig/cassandra:2.1.21.14
+        - image: quay.io/sysdig/cassandra:2.1.21.15
           name: cassandra
           env:
             - name: CASSANDRA_SERVICE

--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
@@ -30,13 +30,13 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: affinity
-                    operator: In
-                    values:
-                      - elasticsearch
-              topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: affinity
+                operator: In
+                values:
+                - elasticsearch
+            topologyKey: kubernetes.io/hostname
       containers:
         - name: elasticsearch
           image: quay.io/sysdig/elasticsearch:5.6.16.14

--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
@@ -30,16 +30,16 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: affinity
-                operator: In
-                values:
-                - elasticsearch
-            topologyKey: kubernetes.io/hostname
+            - labelSelector:
+                matchExpressions:
+                  - key: affinity
+                    operator: In
+                    values:
+                      - elasticsearch
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: elasticsearch
-          image: quay.io/sysdig/elasticsearch:5.6.16.13
+          image: quay.io/sysdig/elasticsearch:5.6.16.14
           securityContext:
             privileged: true
           ## Recommended resource limits for Elasticsearch pods.

--- a/datastores/as_kubernetes_pods/manifests/postgres/postgres-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/postgres/postgres-statefulset.yaml
@@ -13,14 +13,14 @@ spec:
       app: sysdigcloud
       role: postgresql
   volumeClaimTemplates:
-  - metadata:
-      name: data
-    spec:
-      accessModes: ["ReadWriteOnce"]
-      resources:
-        requests:
-          storage: 60Gi
-      storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 60Gi
+        storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
   template:
     metadata:
       labels:
@@ -30,57 +30,57 @@ spec:
       imagePullSecrets:
         - name: sysdigcloud-pull-secret
       containers:
-      - name: postgresql
-        image: quay.io/sysdig/postgres:10.6.10
-        resources: {}
-        env:
-        - name: POSTGRES_USER
-          valueFrom:
-            configMapKeyRef:
-              name: sysdigcloud-config
-              key: anchore.db.user
-          # Required for pg_isready in the health probes.
-        - name: PGUSER
-          valueFrom:
-            configMapKeyRef:
-              name: sysdigcloud-config
-              key: anchore.db.user
-        - name: POSTGRES_DB
-          valueFrom:
-            configMapKeyRef:
-              name: sysdigcloud-config
-              key: anchore.db.dbname
-        - name: PGDATA
-          value: /var/lib/postgresql/data/pgdata
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: sysdigcloud-anchore
-              key: anchore.db.password
-        - name: POD_IP
-          valueFrom: { fieldRef: { fieldPath: status.podIP } }
-        ports:
         - name: postgresql
-          containerPort: 5432
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - exec pg_isready --host $POD_IP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-          failureThreshold: 6
-        readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - exec pg_isready --host $POD_IP
-          initialDelaySeconds: 5
-          timeoutSeconds: 3
-          periodSeconds: 5
-        volumeMounts:
-        - name: data
-          mountPath: /var/lib/postgresql/data/pgdata
-          subPath: "postgresql-db"
+          image: quay.io/sysdig/postgres:10.6.11
+          resources: {}
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-config
+                  key: anchore.db.user
+              # Required for pg_isready in the health probes.
+            - name: PGUSER
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-config
+                  key: anchore.db.user
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-config
+                  key: anchore.db.dbname
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sysdigcloud-anchore
+                  key: anchore.db.password
+            - name: POD_IP
+              valueFrom: { fieldRef: { fieldPath: status.podIP } }
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exec pg_isready --host $POD_IP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exec pg_isready --host $POD_IP
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+            periodSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data/pgdata
+              subPath: "postgresql-db"

--- a/datastores/as_kubernetes_pods/manifests/postgres/postgres-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/postgres/postgres-statefulset.yaml
@@ -13,14 +13,14 @@ spec:
       app: sysdigcloud
       role: postgresql
   volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 60Gi
-        storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 60Gi
+      storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
   template:
     metadata:
       labels:
@@ -30,57 +30,57 @@ spec:
       imagePullSecrets:
         - name: sysdigcloud-pull-secret
       containers:
+      - name: postgresql
+        image: quay.io/sysdig/postgres:10.6.11
+        resources: {}
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-config
+              key: anchore.db.user
+          # Required for pg_isready in the health probes.
+        - name: PGUSER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-config
+              key: anchore.db.user
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-config
+              key: anchore.db.dbname
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sysdigcloud-anchore
+              key: anchore.db.password
+        - name: POD_IP
+          valueFrom: { fieldRef: { fieldPath: status.podIP } }
+        ports:
         - name: postgresql
-          image: quay.io/sysdig/postgres:10.6.11
-          resources: {}
-          env:
-            - name: POSTGRES_USER
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-config
-                  key: anchore.db.user
-              # Required for pg_isready in the health probes.
-            - name: PGUSER
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-config
-                  key: anchore.db.user
-            - name: POSTGRES_DB
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-config
-                  key: anchore.db.dbname
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: sysdigcloud-anchore
-                  key: anchore.db.password
-            - name: POD_IP
-              valueFrom: { fieldRef: { fieldPath: status.podIP } }
-          ports:
-            - name: postgresql
-              containerPort: 5432
-          livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - exec pg_isready --host $POD_IP
-            initialDelaySeconds: 60
-            timeoutSeconds: 5
-            failureThreshold: 6
-          readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - exec pg_isready --host $POD_IP
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-            periodSeconds: 5
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/postgresql/data/pgdata
-              subPath: "postgresql-db"
+          containerPort: 5432
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          periodSeconds: 5
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data/pgdata
+          subPath: "postgresql-db"

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-deployment.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-deployment.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: quay.io/sysdig/redis:4.0.12.6
+          image: quay.io/sysdig/redis:4.0.12.7
           resources:
             limits:
               cpu: 2

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-primary-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-primary-statefulset.yaml
@@ -12,16 +12,16 @@ spec:
         app: redis-primary
     spec:
       affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                      - redis-secondary
-                      - redis-primary
-              topologyKey: "kubernetes.io/hostname"
+       podAntiAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+         - labelSelector:
+             matchExpressions:
+             - key: app
+               operator: In
+               values:
+               - redis-secondary
+               - redis-primary
+           topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 10
       containers:
         - name: redis-primary

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-primary-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-primary-statefulset.yaml
@@ -12,20 +12,20 @@ spec:
         app: redis-primary
     spec:
       affinity:
-       podAntiAffinity:
-         requiredDuringSchedulingIgnoredDuringExecution:
-         - labelSelector:
-             matchExpressions:
-             - key: app
-               operator: In
-               values:
-               - redis-secondary
-               - redis-primary
-           topologyKey: "kubernetes.io/hostname"
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - redis-secondary
+                      - redis-primary
+              topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 10
       containers:
         - name: redis-primary
-          image: quay.io/sysdig/redis:4.0.12.7-ha
+          image: quay.io/sysdig/redis:4.0.12.8-ha
           env:
             - name: REDIS_PASSWORD
               valueFrom:

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-secondary-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-secondary-statefulset.yaml
@@ -12,16 +12,16 @@ spec:
         app: redis-secondary
     spec:
       affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                      - redis-secondary
-                      - redis-primary
-              topologyKey: "kubernetes.io/hostname"
+       podAntiAffinity:
+         requiredDuringSchedulingIgnoredDuringExecution:
+         - labelSelector:
+             matchExpressions:
+             - key: app
+               operator: In
+               values:
+               - redis-secondary
+               - redis-primary
+           topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 10
       containers:
         - name: redis-secondary

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-secondary-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-secondary-statefulset.yaml
@@ -12,20 +12,20 @@ spec:
         app: redis-secondary
     spec:
       affinity:
-       podAntiAffinity:
-         requiredDuringSchedulingIgnoredDuringExecution:
-         - labelSelector:
-             matchExpressions:
-             - key: app
-               operator: In
-               values:
-               - redis-secondary
-               - redis-primary
-           topologyKey: "kubernetes.io/hostname"
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - redis-secondary
+                      - redis-primary
+              topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 10
       containers:
         - name: redis-secondary
-          image: quay.io/sysdig/redis:4.0.12.7-ha
+          image: quay.io/sysdig/redis:4.0.12.8-ha
           imagePullPolicy: Always
           env:
             - name: REDIS_PASSWORD

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-sentinel-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-sentinel-statefulset.yaml
@@ -14,35 +14,35 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: app
-                    operator: In
-                    values:
-                      - redis-sentinel
-              topologyKey: "kubernetes.io/hostname"
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - redis-sentinel
+            topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 10
       containers:
-        - name: redis-sentinel
-          image: quay.io/sysdig/redis:4.0.12.8-ha
-          imagePullPolicy: Always
-          env:
-            - name: SENTINEL
-              value: redis-primary
-            - name: REDIS_PASSWORD
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-config
-                  key: redis.password
-          resources:
-            limits:
-              cpu: 300m
-              memory: 20Mi
-            requests:
-              cpu: 50m
-              memory: 5Mi
-          ports:
-            - containerPort: 26379
-              name: redis-sentinel
+      - name: redis-sentinel
+        image: quay.io/sysdig/redis:4.0.12.8-ha
+        imagePullPolicy: Always
+        env:
+        - name: SENTINEL
+          value: redis-primary
+        - name: REDIS_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-config
+              key: redis.password
+        resources:
+          limits:
+            cpu: 300m
+            memory: 20Mi
+          requests:
+            cpu: 50m
+            memory: 5Mi
+        ports:
+        - containerPort: 26379
+          name: redis-sentinel
       imagePullSecrets:
         - name: sysdigcloud-pull-secret

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-sentinel-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-sentinel-statefulset.yaml
@@ -14,35 +14,35 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - redis-sentinel
-            topologyKey: "kubernetes.io/hostname"
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - redis-sentinel
+              topologyKey: "kubernetes.io/hostname"
       terminationGracePeriodSeconds: 10
       containers:
-      - name: redis-sentinel
-        image: quay.io/sysdig/redis:4.0.12.7-ha
-        imagePullPolicy: Always
-        env:
-        - name: SENTINEL
-          value: redis-primary
-        - name: REDIS_PASSWORD
-          valueFrom:
-            configMapKeyRef:
-              name: sysdigcloud-config
-              key: redis.password
-        resources:
-          limits:
-            cpu: 300m
-            memory: 20Mi
-          requests:
-            cpu: 50m
-            memory: 5Mi
-        ports:
-        - containerPort: 26379
-          name: redis-sentinel
+        - name: redis-sentinel
+          image: quay.io/sysdig/redis:4.0.12.8-ha
+          imagePullPolicy: Always
+          env:
+            - name: SENTINEL
+              value: redis-primary
+            - name: REDIS_PASSWORD
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-config
+                  key: redis.password
+          resources:
+            limits:
+              cpu: 300m
+              memory: 20Mi
+            requests:
+              cpu: 50m
+              memory: 5Mi
+          ports:
+            - containerPort: 26379
+              name: redis-sentinel
       imagePullSecrets:
         - name: sysdigcloud-pull-secret

--- a/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-db-statefulset.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-db-statefulset.yaml
@@ -16,15 +16,15 @@ spec:
       app: sysdigcloud
       role: anchore-feeds-db
   volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
-        resources:
-          requests:
-            storage: 8Gi
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+       - ReadWriteOnce
+      storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
+      resources:
+        requests:
+          storage: 8Gi
   template:
     metadata:
       labels:
@@ -40,67 +40,67 @@ spec:
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: role
-                      operator: In
-                      values:
-                        - anchore-feeds
-                topologyKey: "kubernetes.io/hostname"
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: role
+                  operator: In
+                  values:
+                  - anchore-feeds
+              topologyKey: "kubernetes.io/hostname"
       containers:
-        - name: postgresql
-          image: quay.io/sysdig/postgres:10.6.11
-          resources: {}
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/postgresql/data/pgdata
-              subPath: "postgresql-db"
-          env:
-            - name: POSTGRES_USER
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-anchore-feeds
-                  key: anchore.db.user
-              # Required for pg_isready in the health probes.
-            - name: PGUSER
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-anchore-feeds
-                  key: anchore.db.user
-            - name: POSTGRES_DB
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-anchore-feeds
-                  key: anchore.db.dbname
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: sysdigcloud-anchore-feeds
-                  key: anchore.db.password
-            - name: POD_IP
-              valueFrom: { fieldRef: { fieldPath: status.podIP } }
-          ports:
-            - name: feeds-db
-              containerPort: 5432
-          livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - exec pg_isready --host $POD_IP
-            initialDelaySeconds: 60
-            timeoutSeconds: 5
-            failureThreshold: 6
-          readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - exec pg_isready --host $POD_IP
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-            periodSeconds: 5
+      - name: postgresql
+        image: quay.io/sysdig/postgres:10.6.11
+        resources: {}
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data/pgdata
+          subPath: "postgresql-db"
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.user
+          # Required for pg_isready in the health probes.
+        - name: PGUSER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.user
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.dbname
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.password
+        - name: POD_IP
+          valueFrom: { fieldRef: { fieldPath: status.podIP } }
+        ports:
+        - name: feeds-db
+          containerPort: 5432
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          periodSeconds: 5

--- a/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-db-statefulset.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-dmz/anchore-feeds-db-statefulset.yaml
@@ -16,15 +16,15 @@ spec:
       app: sysdigcloud
       role: anchore-feeds-db
   volumeClaimTemplates:
-  - metadata:
-      name: data
-    spec:
-      accessModes:
-       - ReadWriteOnce
-      storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
-      resources:
-        requests:
-          storage: 8Gi
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
+        resources:
+          requests:
+            storage: 8Gi
   template:
     metadata:
       labels:
@@ -40,67 +40,67 @@ spec:
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: role
-                  operator: In
-                  values:
-                  - anchore-feeds
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: role
+                      operator: In
+                      values:
+                        - anchore-feeds
+                topologyKey: "kubernetes.io/hostname"
       containers:
-      - name: postgresql
-        image: quay.io/sysdig/postgres:10.6.10
-        resources: {}
-        volumeMounts:
-        - name: data
-          mountPath: /var/lib/postgresql/data/pgdata
-          subPath: "postgresql-db"
-        env:
-        - name: POSTGRES_USER
-          valueFrom:
-            configMapKeyRef:
-              name: sysdigcloud-anchore-feeds
-              key: anchore.db.user
-          # Required for pg_isready in the health probes.
-        - name: PGUSER
-          valueFrom:
-            configMapKeyRef:
-              name: sysdigcloud-anchore-feeds
-              key: anchore.db.user
-        - name: POSTGRES_DB
-          valueFrom:
-            configMapKeyRef:
-              name: sysdigcloud-anchore-feeds
-              key: anchore.db.dbname
-        - name: PGDATA
-          value: /var/lib/postgresql/data/pgdata
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: sysdigcloud-anchore-feeds
-              key: anchore.db.password
-        - name: POD_IP
-          valueFrom: { fieldRef: { fieldPath: status.podIP } }
-        ports:
-        - name: feeds-db
-          containerPort: 5432
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - exec pg_isready --host $POD_IP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-          failureThreshold: 6
-        readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - exec pg_isready --host $POD_IP
-          initialDelaySeconds: 5
-          timeoutSeconds: 3
-          periodSeconds: 5
+        - name: postgresql
+          image: quay.io/sysdig/postgres:10.6.11
+          resources: {}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data/pgdata
+              subPath: "postgresql-db"
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-anchore-feeds
+                  key: anchore.db.user
+              # Required for pg_isready in the health probes.
+            - name: PGUSER
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-anchore-feeds
+                  key: anchore.db.user
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-anchore-feeds
+                  key: anchore.db.dbname
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sysdigcloud-anchore-feeds
+                  key: anchore.db.password
+            - name: POD_IP
+              valueFrom: { fieldRef: { fieldPath: status.podIP } }
+          ports:
+            - name: feeds-db
+              containerPort: 5432
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exec pg_isready --host $POD_IP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exec pg_isready --host $POD_IP
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+            periodSeconds: 5

--- a/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-db-statefulset.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-db-statefulset.yaml
@@ -16,15 +16,15 @@ spec:
       app: sysdigcloud
       role: anchore-feeds-db
   volumeClaimTemplates:
-  - metadata:
-      name: anchore-feeds-data
-    spec:
-      accessModes:
-       - ReadWriteOnce
-      storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
-      resources:
-        requests:
-          storage: 5Gi
+    - metadata:
+        name: anchore-feeds-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
+        resources:
+          requests:
+            storage: 5Gi
   template:
     metadata:
       labels:
@@ -40,67 +40,67 @@ spec:
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: role
-                  operator: In
-                  values:
-                  - anchore-feeds
-              topologyKey: "kubernetes.io/hostname"
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: role
+                      operator: In
+                      values:
+                        - anchore-feeds
+                topologyKey: "kubernetes.io/hostname"
       containers:
-      - name: postgresql
-        image: quay.io/sysdig/postgres:10.6.10
-        resources: {}
-        volumeMounts:
-        - name: anchore-feeds-data
-          mountPath: /var/lib/postgresql/data/pgdata
-          subPath: "postgresql-db"
-        env:
-        - name: POSTGRES_USER
-          valueFrom:
-            configMapKeyRef:
-              name: sysdigcloud-anchore-feeds
-              key: anchore.db.user
-          # Required for pg_isready in the health probes.
-        - name: PGUSER
-          valueFrom:
-            configMapKeyRef:
-              name: sysdigcloud-anchore-feeds
-              key: anchore.db.user
-        - name: POSTGRES_DB
-          valueFrom:
-            configMapKeyRef:
-              name: sysdigcloud-anchore-feeds
-              key: anchore.db.dbname
-        - name: PGDATA
-          value: /var/lib/postgresql/data/pgdata
-        - name: POSTGRES_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: sysdigcloud-anchore-feeds
-              key: anchore.db.password
-        - name: POD_IP
-          valueFrom: { fieldRef: { fieldPath: status.podIP } }
-        ports:
-        - name: feeds-db
-          containerPort: 5432
-        livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - exec pg_isready --host $POD_IP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-          failureThreshold: 6
-        readinessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - exec pg_isready --host $POD_IP
-          initialDelaySeconds: 5
-          timeoutSeconds: 3
-          periodSeconds: 5
+        - name: postgresql
+          image: quay.io/sysdig/postgres:10.6.11
+          resources: {}
+          volumeMounts:
+            - name: anchore-feeds-data
+              mountPath: /var/lib/postgresql/data/pgdata
+              subPath: "postgresql-db"
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-anchore-feeds
+                  key: anchore.db.user
+              # Required for pg_isready in the health probes.
+            - name: PGUSER
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-anchore-feeds
+                  key: anchore.db.user
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: sysdigcloud-anchore-feeds
+                  key: anchore.db.dbname
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sysdigcloud-anchore-feeds
+                  key: anchore.db.password
+            - name: POD_IP
+              valueFrom: { fieldRef: { fieldPath: status.podIP } }
+          ports:
+            - name: feeds-db
+              containerPort: 5432
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exec pg_isready --host $POD_IP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exec pg_isready --host $POD_IP
+            initialDelaySeconds: 5
+            timeoutSeconds: 3
+            periodSeconds: 5

--- a/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-db-statefulset.yaml
+++ b/sysdigcloud/anchore-feed/anchore-feed-secluded/anchore-feeds-db-statefulset.yaml
@@ -16,15 +16,15 @@ spec:
       app: sysdigcloud
       role: anchore-feeds-db
   volumeClaimTemplates:
-    - metadata:
-        name: anchore-feeds-data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
-        resources:
-          requests:
-            storage: 5Gi
+  - metadata:
+      name: anchore-feeds-data
+    spec:
+      accessModes:
+       - ReadWriteOnce
+      storageClassName: <INSERT_YOUR_STORAGE_CLASS_NAME>
+      resources:
+        requests:
+          storage: 5Gi
   template:
     metadata:
       labels:
@@ -40,67 +40,67 @@ spec:
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 1
-              podAffinityTerm:
-                labelSelector:
-                  matchExpressions:
-                    - key: role
-                      operator: In
-                      values:
-                        - anchore-feeds
-                topologyKey: "kubernetes.io/hostname"
+          - weight: 1
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: role
+                  operator: In
+                  values:
+                  - anchore-feeds
+              topologyKey: "kubernetes.io/hostname"
       containers:
-        - name: postgresql
-          image: quay.io/sysdig/postgres:10.6.11
-          resources: {}
-          volumeMounts:
-            - name: anchore-feeds-data
-              mountPath: /var/lib/postgresql/data/pgdata
-              subPath: "postgresql-db"
-          env:
-            - name: POSTGRES_USER
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-anchore-feeds
-                  key: anchore.db.user
-              # Required for pg_isready in the health probes.
-            - name: PGUSER
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-anchore-feeds
-                  key: anchore.db.user
-            - name: POSTGRES_DB
-              valueFrom:
-                configMapKeyRef:
-                  name: sysdigcloud-anchore-feeds
-                  key: anchore.db.dbname
-            - name: PGDATA
-              value: /var/lib/postgresql/data/pgdata
-            - name: POSTGRES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: sysdigcloud-anchore-feeds
-                  key: anchore.db.password
-            - name: POD_IP
-              valueFrom: { fieldRef: { fieldPath: status.podIP } }
-          ports:
-            - name: feeds-db
-              containerPort: 5432
-          livenessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - exec pg_isready --host $POD_IP
-            initialDelaySeconds: 60
-            timeoutSeconds: 5
-            failureThreshold: 6
-          readinessProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - exec pg_isready --host $POD_IP
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-            periodSeconds: 5
+      - name: postgresql
+        image: quay.io/sysdig/postgres:10.6.11
+        resources: {}
+        volumeMounts:
+        - name: anchore-feeds-data
+          mountPath: /var/lib/postgresql/data/pgdata
+          subPath: "postgresql-db"
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.user
+          # Required for pg_isready in the health probes.
+        - name: PGUSER
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.user
+        - name: POSTGRES_DB
+          valueFrom:
+            configMapKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.dbname
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pgdata
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sysdigcloud-anchore-feeds
+              key: anchore.db.password
+        - name: POD_IP
+          valueFrom: { fieldRef: { fieldPath: status.podIP } }
+        ports:
+        - name: feeds-db
+          containerPort: 5432
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - exec pg_isready --host $POD_IP
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          periodSeconds: 5

--- a/sysdigcloud/ingress_controller/ingress-daemonset.yaml
+++ b/sysdigcloud/ingress_controller/ingress-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         # When we upgrade to an ingress controller with HAProxy 1.9 we should
         # remove this and use HAProxy's logging to stdout functionality
-        - image: "quay.io/sysdig/rsyslog:8.34.0.5"
+        - image: "quay.io/sysdig/rsyslog:8.34.0.6"
           imagePullPolicy: Always
           name: rsyslog-server
           resources:
@@ -34,11 +34,11 @@ spec:
         - name: haproxy-ingress
           image: quay.io/sysdig/haproxy-ingress:v0.7-beta.7
           args:
-              - --default-backend-service=$(POD_NAMESPACE)/ingress-default-backend
-              - --allow-cross-namespace
-              - --configmap=$(POD_NAMESPACE)/haproxy-ingress
-              - --tcp-services-configmap=$(POD_NAMESPACE)/haproxy-tcp-services
-              - --default-ssl-certificate=$(POD_NAMESPACE)/sysdigcloud-ssl-secret
+            - --default-backend-service=$(POD_NAMESPACE)/ingress-default-backend
+            - --allow-cross-namespace
+            - --configmap=$(POD_NAMESPACE)/haproxy-ingress
+            - --tcp-services-configmap=$(POD_NAMESPACE)/haproxy-tcp-services
+            - --default-ssl-certificate=$(POD_NAMESPACE)/sysdigcloud-ssl-secret
           ports:
             - containerPort: 10253
               hostPort: 10253
@@ -57,21 +57,21 @@ spec:
               name: tlscollector
               protocol: TCP
           readinessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /healthz
-                port: 10253
-                scheme: HTTP
-              periodSeconds: 10
-              successThreshold: 1
-              timeoutSeconds: 1
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10253
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           resources:
-              limits:
-                cpu: 2
-                memory: 2Gi
-              requests:
-                cpu: 100m
-                memory: 100Mi
+            limits:
+              cpu: 2
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 100Mi
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/sysdigcloud/ingress_controller/ingress-daemonset.yaml
+++ b/sysdigcloud/ingress_controller/ingress-daemonset.yaml
@@ -34,11 +34,11 @@ spec:
         - name: haproxy-ingress
           image: quay.io/sysdig/haproxy-ingress:v0.7-beta.7
           args:
-            - --default-backend-service=$(POD_NAMESPACE)/ingress-default-backend
-            - --allow-cross-namespace
-            - --configmap=$(POD_NAMESPACE)/haproxy-ingress
-            - --tcp-services-configmap=$(POD_NAMESPACE)/haproxy-tcp-services
-            - --default-ssl-certificate=$(POD_NAMESPACE)/sysdigcloud-ssl-secret
+              - --default-backend-service=$(POD_NAMESPACE)/ingress-default-backend
+              - --allow-cross-namespace
+              - --configmap=$(POD_NAMESPACE)/haproxy-ingress
+              - --tcp-services-configmap=$(POD_NAMESPACE)/haproxy-tcp-services
+              - --default-ssl-certificate=$(POD_NAMESPACE)/sysdigcloud-ssl-secret
           ports:
             - containerPort: 10253
               hostPort: 10253
@@ -57,21 +57,21 @@ spec:
               name: tlscollector
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /healthz
-              port: 10253
-              scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
+              failureThreshold: 3
+              httpGet:
+                path: /healthz
+                port: 10253
+                scheme: HTTP
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 1
           resources:
-            limits:
-              cpu: 2
-              memory: 2Gi
-            requests:
-              cpu: 100m
-              memory: 100Mi
+              limits:
+                cpu: 2
+                memory: 2Gi
+              requests:
+                cpu: 100m
+                memory: 100Mi
           livenessProbe:
             failureThreshold: 3
             httpGet:


### PR DESCRIPTION
Images that need to have their CVE Version bumped up

- rsyslog
- postgres
- cassandra
- elasticsearch
- haproxy
- haproxy-ingress
- redis

haproxy-ingress image has not been updated. Just haproxy is not being used here.