### PR TITLE
Remove deprecated APIs because of 1.16 release

### DIFF
--- a/datastores/as_kubernetes_pods/README.md
+++ b/datastores/as_kubernetes_pods/README.md
@@ -251,12 +251,14 @@ To specify JVM options for a specific pod first deploy the [cassandra-jvm-opts-c
 Add the following sections to the StatefulSet (examples are included in comments which can simply be uncommented):
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: sysdigcloud-cassandra
 ...
 spec:
+  selector:
+...
   template:
 ...
     spec:

--- a/datastores/as_kubernetes_pods/manifests/cassandra/cassandra-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/cassandra/cassandra-statefulset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: sysdigcloud-cassandra

--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: sysdigcloud-elasticsearch
@@ -9,6 +9,12 @@ metadata:
     component: elasticsearch
     role: elasticsearch
 spec:
+  selector:
+    matchLabels:
+        affinity: elasticsearch
+        app: sysdigcloud
+        component: elasticsearch
+        role: elasticsearch
   updateStrategy:
     type: OnDelete
   serviceName: sysdigcloud-elasticsearch

--- a/datastores/as_kubernetes_pods/manifests/mysql/mysql-deployment.yaml
+++ b/datastores/as_kubernetes_pods/manifests/mysql/mysql-deployment.yaml
@@ -69,11 +69,15 @@ spec:
     app: sysdigcloud
     role: mysql
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sysdigcloud-mysql
 spec:
+  selector:
+    matchLabels:
+      app: sysdigcloud
+      role: mysql
   template:
     metadata:
       labels:

--- a/datastores/as_kubernetes_pods/manifests/mysql/mysql-router-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/mysql/mysql-router-statefulset.yaml
@@ -14,11 +14,15 @@ spec:
     app: sysdigcloud
     role: mysql-router
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sysdigcloud-mysql-router
 spec:
+  selector:
+    matchLabels:
+      app: sysdigcloud
+      role: mysql-router
   replicas: 3
   template:
     metadata:

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-deployment.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-deployment.yaml
@@ -13,11 +13,14 @@ spec:
     app: sysdigcloud
     role: redis
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sysdigcloud-redis
 spec:
+  selector:
+    app: sysdigcloud
+    role: redis
   template:
     metadata:
       labels:

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-deployment.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-deployment.yaml
@@ -19,8 +19,9 @@ metadata:
   name: sysdigcloud-redis
 spec:
   selector:
-    app: sysdigcloud
-    role: redis
+    matchLabels:
+      app: sysdigcloud
+      role: redis
   template:
     metadata:
       labels:

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-primary-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-primary-statefulset.yaml
@@ -1,9 +1,12 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis-primary
 spec:
+  selector:
+    matchLabels:
+      app: redis-primary
   serviceName: redis-primary
   replicas: 1
   template:

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-secondary-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-secondary-statefulset.yaml
@@ -1,9 +1,12 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis-secondary
 spec:
+  selector:
+    matchLabels:
+      app: redis-secondary
   serviceName: redis-secondary
   replicas: 2
   template:

--- a/datastores/as_kubernetes_pods/manifests/redis/redis-sentinel-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/redis/redis-sentinel-statefulset.yaml
@@ -1,9 +1,12 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis-sentinel
 spec:
+  selector:
+    matchLabels:
+      app: redis-sentinel
   serviceName: redis-sentinel
   replicas: 3
   template:

--- a/sysdigcloud/api-deployment.yaml
+++ b/sysdigcloud/api-deployment.yaml
@@ -3,6 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sysdigcloud-api
+  labels:
+    app: sysdigcloud
+    role: api
 spec:
   selector:
     matchLabels:

--- a/sysdigcloud/api-deployment.yaml
+++ b/sysdigcloud/api-deployment.yaml
@@ -1,9 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sysdigcloud-api
 spec:
+  selector:
+    matchLabels:
+      app: sysdigcloud
+      role: api
   replicas: 1
   template:
     metadata:

--- a/sysdigcloud/collector-deployment.yaml
+++ b/sysdigcloud/collector-deployment.yaml
@@ -1,9 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sysdigcloud-collector
 spec:
+  selector:
+    matchLabels:
+      app: sysdigcloud
+      role: collector
   replicas: 1
   template:
     metadata:

--- a/sysdigcloud/collector-deployment.yaml
+++ b/sysdigcloud/collector-deployment.yaml
@@ -3,6 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sysdigcloud-collector
+  labels:
+    app: sysdigcloud
+    role: collector
 spec:
   selector:
     matchLabels:

--- a/sysdigcloud/worker-deployment.yaml
+++ b/sysdigcloud/worker-deployment.yaml
@@ -1,9 +1,13 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sysdigcloud-worker
 spec:
+  selector:
+    matchLabels:
+      app: sysdigcloud
+      role: worker
   replicas: 1
   template:
     metadata:

--- a/sysdigcloud/worker-deployment.yaml
+++ b/sysdigcloud/worker-deployment.yaml
@@ -3,6 +3,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sysdigcloud-worker
+  labels:
+    app: sysdigcloud
+    role: worker
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Update YAMLs because of `1.16` release: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
This will make these YAMLs to fail in kubernetes versions prior to `1.9`.

I have not properly tested this, but it can be reviewed; I'd like to test this when `onprem-2019-09` is merged.