### PR TITLE
Updated vulnerability versions for elasticsearch and rsyslog.

### DIFF
--- a/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
+++ b/datastores/as_kubernetes_pods/manifests/elasticsearch/elasticsearch-statefulset.yaml
@@ -45,7 +45,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
         - name: elasticsearch
-          image: quay.io/sysdig/elasticsearch:5.6.16.14
+          image: quay.io/sysdig/elasticsearch:5.6.16.15
           securityContext:
             privileged: true
           ## Recommended resource limits for Elasticsearch pods.

--- a/sysdigcloud/ingress_controller/ingress-daemonset.yaml
+++ b/sysdigcloud/ingress_controller/ingress-daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
         # When we upgrade to an ingress controller with HAProxy 1.9 we should
         # remove this and use HAProxy's logging to stdout functionality
-        - image: "quay.io/sysdig/rsyslog:8.34.0.6"
+        - image: "quay.io/sysdig/rsyslog:8.34.0.7"
           imagePullPolicy: Always
           name: rsyslog-server
           resources:


### PR DESCRIPTION
Updated rsyslog and es version and their references.

- Elasticsearch - All OS critical and high are resolved. Latest Scan result
- rsyslog - Most of the OS critical and high are resolved. There are two that weren't. Latest Scan result
