### PR TITLE
DEVOPS-3081 - Update cve versions for docker images

### DIFF
--- a/sysdigcloud/ingress_controller/ingress-daemonset.yaml
+++ b/sysdigcloud/ingress_controller/ingress-daemonset.yaml
@@ -32,7 +32,7 @@ spec:
               cpu: 50m
               memory: 10Mi
         - name: haproxy-ingress
-          image: quay.io/sysdig/haproxy-ingress:v0.7-beta.7
+          image: quay.io/sysdig/haproxy-ingress:v0.7-beta.7.1
           args:
               - --default-backend-service=$(POD_NAMESPACE)/ingress-default-backend
               - --allow-cross-namespace


### PR DESCRIPTION
Updated haproxy-ingress docker image cve version.